### PR TITLE
Update builder.php to use the actual closure class

### DIFF
--- a/src/SCM/MySQLe/Database/Schema/Builder.php
+++ b/src/SCM/MySQLe/Database/Schema/Builder.php
@@ -8,10 +8,10 @@ class Builder extends MySqlBuilder {
      * Create a new command set with a Closure.
      *
      * @param  string   $table
-     * @param  Closure  $callback
+     * @param  \Closure  $callback
      * @return \SCM\MySQLe\Database\Schema\Blueprint
      */
-    protected function createBlueprint($table, Closure $callback = null)
+    protected function createBlueprint($table, \Closure $callback = null)
     {
         return new Blueprint($table, $callback);
     }


### PR DESCRIPTION
This was breaking a situation where I tried to add a migration to update the database,  I was getting the following error:

Argument 2 passed to SCM\MySQLe\Database\Schema\Builder::table() must be an instance of SCM\MySQLe\Database\Schema\Closure, instance of Closure given, called in /home/tom/Projects/zip/zip-hydrotap-code/zip-api/vendor/laravel/f  
  ramework/src/Illuminate/Support/Facades/Facade.php on line 211 and defined 

Trying to do something like:

 Schema::table('<Tablename>', function (Blueprint $table) {
            $table->string('sub_unit')->after('hydrotap_location_id')->nullable();
        });

```
    Schema::table('<Tablename>', function (Blueprint $table) {
        $table->string('sub_unit')->after('name')->nullable();
    });
```
